### PR TITLE
Date de mise à jour : format littéral

### DIFF
--- a/build/version.js
+++ b/build/version.js
@@ -2,7 +2,9 @@ const replace = require('replace-in-file');
 const gitCommitInfo = require('git-commit-info');
 
 const commitInfo = gitCommitInfo();
-const dateString = new Date(commitInfo.date).toLocaleDateString("fr");
+
+const dateFormatOptions = {year: 'numeric', month: 'long', day: 'numeric' };
+const dateString = new Date(commitInfo.date).toLocaleDateString('fr-FR', dateFormatOptions);
 
 const options = {
   files: 'dist/index.html',


### PR DESCRIPTION
Format de la date de mise à jour (du commit ayant  déclenché le déploiement)

Passage au format `11 mai 2023` plutôt que `11/05/2023`